### PR TITLE
 Mistral 7B v0.3 Support - Resolves part of #2

### DIFF
--- a/umbrella/models/auto_model.py
+++ b/umbrella/models/auto_model.py
@@ -133,7 +133,8 @@ class AutoModelLM:
         "mistralai/Mistral-Small-24B-Instruct-2501": Mistral,
         "stelterlab/Mistral-Small-24B-Instruct-2501-AWQ": MistralAwq,
         "PyrTools/Ministral-8B-Instruct-2410-AWQ": MistralAwq,
-        "mistralai/Ministral-8B-Instruct-2410": Mistral
+        "mistralai/Ministral-8B-Instruct-2410": Mistral,
+        "mistralai/Mistral-7B-v0.3": Mistral,
     }
 
     _CUDAGRAPH_MODEL_MAPPING = {


### PR DESCRIPTION
As we discussed earlier, there are implementations of mistral concurrently on both sides, after comparison, there is no meaningful difference on mistral.py, mistral_layer.py, and templates.py, so only auto_model.py is updated here and it is tested with its output answer correctly.

Although everything works fine, one thing to note is that **generate.py** works well using `DEVICE = "cuda:0"` in **line 20**, but not if using other gpus like changing that line to `DEVICE = "cuda:1"` instead. The bug would fall into **cache.py** **line 79**:
 `hidden_states = flashinfer.single_prefill_with_kv_cache(`
with message: 
  File "/home/zhuominc/anaconda3/envs/junpuy_test/lib/python3.10/site-packages/flashinfer/prefill.py", line 186, in single_prefill_with_kv_cache
    packed_custom_mask = packbits(
  File "/home/zhuominc/anaconda3/envs/junpuy_test/lib/python3.10/site-packages/flashinfer/quantization.py", line 65, in packbits
    return _kernels.packbits(x, bitorder)
RuntimeError: PackBits failed with error code an illegal memory access was encountered

I'm not sure if that is expected or it is something to figure out